### PR TITLE
use correct startEffectIndex param

### DIFF
--- a/src/context/stateContext/index.tsx
+++ b/src/context/stateContext/index.tsx
@@ -83,7 +83,7 @@ export const AppStateProvider: React.FC<{
   const computeTimer = React.useRef<NodeJS.Timeout | null>(null);
 
   const compute = useProcessingQueue({
-    processFn: ({ state }: { state: AppState }) => {
+    processFn: ({ state, startEffectIndex }: { state: AppState, startEffectIndex: number }) => {
       // Handle frame count changes
       const newBaseImage = (() => {
         const baseImage = state.baseImage;
@@ -105,7 +105,7 @@ export const AppStateProvider: React.FC<{
           ...state,
           baseImage: newBaseImage,
         },
-        startEffectIndex: 0,
+        startEffectIndex,
       });
     },
     onComplete: (computedState) => {
@@ -129,6 +129,7 @@ export const AppStateProvider: React.FC<{
           setState_internal(savedState, { doNotStore: true });
           compute({
             state: savedState,
+            startEffectIndex: 0,
           });
         } else {
           setState_internal(DEFAULT_STATE);
@@ -184,6 +185,7 @@ export const AppStateProvider: React.FC<{
 
           compute({
             state: newState,
+            startEffectIndex: stateDiff.index,
           });
         } else {
           // If no changes, we don't need to compute anything


### PR DESCRIPTION
Closes #31 

This makes the gif computation more efficient by skipping computation for  effect that did not change

if the image has effects

`[A, B, C, D]` and effect `C` was modified, only re-compute effects `C and D`