### PR TITLE
Update pnpm-lock.yaml to remove @vitejs/plugin-basic-ssl

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,9 +90,6 @@ importers:
       '@types/react-dom':
         specifier: ^19.1.2
         version: 19.1.2(@types/react@19.1.2)
-      '@vitejs/plugin-basic-ssl':
-        specifier: ^2.3.0
-        version: 2.3.0(vite@6.3.2(@types/node@22.14.1)(terser@5.39.0))
       '@vitejs/plugin-react':
         specifier: ^4.4.1
         version: 4.4.1(vite@6.3.2(@types/node@22.14.1)(terser@5.39.0))
@@ -975,12 +972,6 @@ packages:
   '@typescript-eslint/visitor-keys@8.30.1':
     resolution: {integrity: sha512-aEhgas7aJ6vZnNFC7K4/vMGDGyOiqWcYZPpIWrTKuTAlsvDNKy2GFDqh9smL+iq069ZvR0YzEeq0B8NJlLzjFA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@vitejs/plugin-basic-ssl@2.3.0':
-    resolution: {integrity: sha512-bdyo8rB3NnQbikdMpHaML9Z1OZPBu6fFOBo+OtxsBlvMJtysWskmBcnbIDhUqgC8tcxNv/a+BcV5U+2nQMm1OQ==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
-    peerDependencies:
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
 
   '@vitejs/plugin-react@4.4.1':
     resolution: {integrity: sha512-IpEm5ZmeXAP/osiBXVVP5KjFMzbWOonMs0NaQQl+xYnUAcq4oHUBsF2+p4MgKWG4YMmFYJU8A6sxRPuowllm6w==}
@@ -3365,10 +3356,6 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.30.1
       eslint-visitor-keys: 4.2.0
-
-  '@vitejs/plugin-basic-ssl@2.3.0(vite@6.3.2(@types/node@22.14.1)(terser@5.39.0))':
-    dependencies:
-      vite: 6.3.2(@types/node@22.14.1)(terser@5.39.0)
 
   '@vitejs/plugin-react@4.4.1(vite@6.3.2(@types/node@22.14.1)(terser@5.39.0))':
     dependencies:


### PR DESCRIPTION
The `@vitejs/plugin-basic-ssl` package was removed from `package.json` but the lock file was not updated at the same time. This PR syncs `pnpm-lock.yaml` to match.